### PR TITLE
Increase base font size to 20px and align blockquote with body

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-$base-font-size: 18px;
+$base-font-size: 20px;
 
 @import "minima";
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -2,6 +2,7 @@
 ---
 
 $base-font-size: 20px;
+$base-line-height: 1.7;
 
 @import "minima";
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -4,3 +4,7 @@
 $base-font-size: 18px;
 
 @import "minima";
+
+blockquote {
+  font-size: $base-font-size;
+}


### PR DESCRIPTION
## 概要
基準フォントサイズ 18px では変化が体感しにくかったため 20px に引き上げます。また、minima テーマの仕様で blockquote が本文の 1.125 倍になり引用だけ大きく見えていたため、本文と同じサイズに揃えます。

## 変更内容
- $base-font-size を 20px に変更（本文・見出しなど全体がこの基準でスケール）
- blockquote の font-size を $base-font-size に固定し、本文と同じ大きさに

🤖 Generated with [Claude Code](https://claude.com/claude-code)