### PR TITLE
Set base font size to 18px and soften text color

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,8 +1,9 @@
 ---
 ---
 
-$base-font-size: 20px;
+$base-font-size: 18px;
 $base-line-height: 1.7;
+$text-color: #333;
 
 @import "minima";
 


### PR DESCRIPTION
## 概要
- 基準フォントサイズを 20px から 18px に戻します
- 文字色を #111 から #333 に変更し、黒を少しやわらげます

行間 1.7 と引用サイズの統一（#2）はそのまま維持しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)