### PR TITLE
Reduce heading sizes

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -10,3 +10,25 @@ $text-color: #333;
 blockquote {
   font-size: $base-font-size;
 }
+
+.post-title {
+  @include relative-font-size(1.75);
+}
+
+.post-list-heading {
+  @include relative-font-size(1.5);
+}
+
+.post-content {
+  h2 {
+    @include relative-font-size(1.5);
+  }
+
+  h3 {
+    @include relative-font-size(1.3);
+  }
+
+  h4 {
+    @include relative-font-size(1.15);
+  }
+}


### PR DESCRIPTION
## 概要
見出しが大きすぎるため、基準フォントサイズに対する倍率を下げます。

## 変更内容
- 記事タイトル（.post-title）: 2.625 倍 → 1.75 倍（47.25px → 31.5px）
- 記事一覧の見出し（.post-list-heading）: 1.75 倍 → 1.5 倍
- 本文の h2: 2 倍 → 1.5 倍（36px → 27px）
- 本文の h3: 1.625 倍 → 1.3 倍
- 本文の h4: 1.25 倍 → 1.15 倍

🤖 Generated with [Claude Code](https://claude.com/claude-code)